### PR TITLE
Allow external plugins to inject their own assets

### DIFF
--- a/templates/presentation.html.twig
+++ b/templates/presentation.html.twig
@@ -80,11 +80,11 @@
         {% do assets.addJs('plugin://presentation/js/modular-scale.js', {'group': 'critical'}) %}
       {% endif %} #}
     {% endblock %}
-    {{ assets.css('critical')|raw }}
-    {{ assets.js('critical')|raw }}
-    {{ assets.css('presentation')|raw }}
-
     {% block assets deferred %}
+      {{ assets.css('critical')|raw }}
+      {{ assets.js('critical')|raw }}
+      {{ assets.css('presentation')|raw }}
+      
       {{ assets.css()|raw }}
       {{ assets.js()|raw }}
     {% endblock %}

--- a/templates/presentation.html.twig
+++ b/templates/presentation.html.twig
@@ -83,6 +83,11 @@
     {{ assets.css('critical')|raw }}
     {{ assets.js('critical')|raw }}
     {{ assets.css('presentation')|raw }}
+
+    {% block assets deferred %}
+      {{ assets.css()|raw }}
+      {{ assets.js()|raw }}
+    {% endblock %}
   </head>
   {% endblock head %}
   <body id="top" class="{{ page.header.body_classes }}">


### PR DESCRIPTION
I'm not sure if this is intentional or not but it would nice if the presentation allowed external plugins to add their own assets (CSS/JS).

For example, I wanted to use [prism highlight](https://github.com/trilbymedia/prism-highlight) but the presentation wouldn't let the CSS to be added in the head, causing code-blocks to default to a monochromatic (and boring) look.

This change fixes that and I can now have nice code-blocks highlights :)

<img width="447" alt="Flex Pages | Grav 2019-08-08 15-33-52" src="https://user-images.githubusercontent.com/11734/62742067-ffb7c000-b9f1-11e9-99ff-75ee9bc36c47.png">
